### PR TITLE
Fix invalid datetime UTC offset error in some pacific timezone

### DIFF
--- a/wmi.go
+++ b/wmi.go
@@ -192,7 +192,8 @@ func parseDateTime(dt string) (time.Time, error) {
 	}
 	// https://learn.microsoft.com/en-us/windows/win32/wmisdk/swbemdatetime-utc
 	off, err := strconv.Atoi(dt[sign:])
-	if err != nil || off < -720 || 720 < off {
+	// Line Islands in the Pacific have UTC+14 (LINT), so we use 840 (UTC+14*60) as the max offset.
+	if err != nil || off < -720 || 840 < off {
 		return time.Time{}, fmt.Errorf("vss: invalid datetime UTC offset: %s", dt)
 	}
 	// https://learn.microsoft.com/en-us/windows/win32/wmisdk/cim-datetime

--- a/wmi_test.go
+++ b/wmi_test.go
@@ -67,3 +67,12 @@ func TestParseDateTime(t *testing.T) {
 	require.Equal(t, want, v.In(zone))
 	require.Equal(t, want.Local(), v)
 }
+
+func TestParseDateTimeLINT(t *testing.T) {
+	zone := time.FixedZone("", 14*60*60)
+	want := time.Date(2023, 12, 13, 01, 22, 50, 108_124_000, zone)
+	v, err := parseDateTime("20231213012250.108124+840")
+	require.NoError(t, err)
+	require.Equal(t, want, v.In(zone))
+	require.Equal(t, want.Local(), v)
+}


### PR DESCRIPTION
It's possible to have offsets greater than 720 in some countries. Currently, the offset for New Zealand is 780, and it seems that the offset for the Line Islands is 840.